### PR TITLE
Implemented load/save contract manager data

### DIFF
--- a/ContractManager/ActiveContractsWindow.cs
+++ b/ContractManager/ActiveContractsWindow.cs
@@ -4,17 +4,15 @@ using ContractManager.ContractBlueprint;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using static KSA.Rendering.PBR.PushConstants.PBRPushConstants;
 
 namespace ContractManager
 {
     internal class ActiveContractsWindow
     {
-        private List<Contract.Contract> _acceptedContracts { get; }
+        private List<Contract.Contract> _acceptedContracts { get { return ContractManager.data.acceptedContracts; } }
 
-        public ActiveContractsWindow(List<Contract.Contract> acceptedContracts)
-        {
-            this._acceptedContracts = acceptedContracts;
-        }
+        public ActiveContractsWindow() { }
 
         public Contract.Contract? DrawActiveContractsWindow()
         {

--- a/ContractManager/Contract/ContractUtils.cs
+++ b/ContractManager/Contract/ContractUtils.cs
@@ -34,7 +34,9 @@ namespace ContractManager.Contract
                 {
                     trackedRequirements[trackedRequirementIndex].status = TrackedRequirementStatus.TRACKED;
                 }
-                if (trackedRequirements[trackedRequirementIndex]._blueprintRequirement.type == ContractBlueprint.RequirementType.Group)
+                if (
+                    trackedRequirements[trackedRequirementIndex]._blueprintRequirement != null &&
+                    trackedRequirements[trackedRequirementIndex]._blueprintRequirement.type == ContractBlueprint.RequirementType.Group)
                 {
                     ContractUtils.UpdateTrackedRequirements(((TrackedGroup)trackedRequirements[trackedRequirementIndex]).trackedRequirements);
                 }
@@ -61,6 +63,7 @@ namespace ContractManager.Contract
             {
                 // Check group childs
                 if (
+                    trackedRequirement._blueprintRequirement != null &&
                     trackedRequirement._blueprintRequirement.type == ContractBlueprint.RequirementType.Group &&
                     ((TrackedGroup)trackedRequirement).trackedRequirements.Count > 0)
                 {
@@ -77,6 +80,36 @@ namespace ContractManager.Contract
                 }
             }
             return worstRequirementStatus;
+        }
+
+        internal static ContractBlueprint.ContractBlueprint? FindContractBlueprintFromUID(List<ContractBlueprint.ContractBlueprint> contractBlueprints, string blueprintUID)
+        {
+            bool foundBlueprint = false;
+            foreach (ContractBlueprint.ContractBlueprint contractBlueprint in contractBlueprints)
+            {
+                foundBlueprint = contractBlueprint.uid == blueprintUID;
+                if (foundBlueprint)
+                {
+                    // Found matching blueprint requirement.
+                    return contractBlueprint;
+                }
+            }
+            return null;
+        }
+
+        internal static ContractBlueprint.Requirement? FindRequirementFromUID(List<ContractBlueprint.Requirement> blueprintRequirements, string requirementUID)
+        {
+            bool foundBlueprintRequirement = false;
+            foreach (ContractBlueprint.Requirement blueprintRequirement in blueprintRequirements)
+            {
+                foundBlueprintRequirement = blueprintRequirement.uid == requirementUID;
+                if (foundBlueprintRequirement)
+                {
+                    // Found matching blueprint requirement.
+                    return blueprintRequirement;
+                }
+            }
+            return null;
         }
 
         // Trigger action of the given type.

--- a/ContractManager/ContractManagementWindow.cs
+++ b/ContractManager/ContractManagementWindow.cs
@@ -12,18 +12,13 @@ namespace ContractManager
     {
         private Contract.Contract? _contractToShowDetails { get; set; } = null;
         
-        private List<Contract.Contract> _offeredContracts { get; }
-        private List<Contract.Contract> _acceptedContracts { get; }
-        private List<Contract.Contract> _finishedContracts { get; }
+        private List<Contract.Contract> _offeredContracts { get { return ContractManager.data.offeredContracts; } }
+        private List<Contract.Contract> _acceptedContracts { get { return ContractManager.data.acceptedContracts; } }
+        private List<Contract.Contract> _finishedContracts { get { return ContractManager.data.finishedContracts; } }
 
         private string _lastActiveTab {  get; set; } = string.Empty;
         
-        public ContractManagementWindow(List<Contract.Contract> offeredContracts, List<Contract.Contract> acceptedContracts, List<Contract.Contract> finishedContracts)
-        {
-            this._offeredContracts = offeredContracts;
-            this._acceptedContracts = acceptedContracts;
-            this._finishedContracts = finishedContracts;
-        }
+        public ContractManagementWindow() { }
 
         public void DrawContractManagementWindow(Contract.Contract? contractToShowDetails)
         {

--- a/ContractManager/ContractManagerData.cs
+++ b/ContractManager/ContractManagerData.cs
@@ -1,0 +1,96 @@
+﻿using KSA;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace ContractManager
+{
+    public class ContractManagerData
+    {
+        // XML serializable fields
+        // List of offered contracts, loaded from save game / file.
+        [XmlElement("offeredContracts")]
+        public List<Contract.Contract> offeredContracts {  get; set; } = new List<Contract.Contract>();
+
+        // List of accepted contracts, loaded from save game / file.
+        [XmlElement("acceptedContracts")]
+        public List<Contract.Contract> acceptedContracts {  get; set; } = new List<Contract.Contract>();
+        
+        // List of finished contracts, loaded from save game / file.
+        [XmlElement("finishedContracts")]
+        public List<Contract.Contract> finishedContracts {  get; set; } = new List<Contract.Contract>();
+
+        // Global ContractManager config of max number of contracts that can be offered simultaneously. Should be determined by the launch site management building.
+        [XmlElement("maxNumberOfOfferedContracts")]
+        public int maxNumberOfOfferedContracts { get; set; } = 2;
+    
+        // Global ContractManager config of max number of contracts that can be accepted simultaneously. Should be determined by the launch site management building.
+        [XmlElement("maxNumberOfAcceptedContracts")]
+        public int maxNumberOfAcceptedContracts { get; set; } = 1;
+        
+        // internal variables
+        // List of all loaded contract blueprints
+        internal List<ContractBlueprint.ContractBlueprint> contractBlueprints { get; set; } = new List<ContractBlueprint.ContractBlueprint>();
+
+        private static XmlSerializer _contractManagerDataXmlSerializer = new XmlSerializer(typeof(ContractManagerData));
+
+        // Load data from save path.
+        public void LoadFrom(string savePath)
+        {
+            Console.WriteLine("[CM] ContractManager.LoadFrom(uncompressedSave)");
+            string filePathContractManagerXmlFile = Path.Combine(savePath, "contractmanager.xml");
+            if (!File.Exists(filePathContractManagerXmlFile))
+            {
+                throw new NullReferenceException("contractmanager file '" + filePathContractManagerXmlFile + "' does not exist");
+            }
+
+            StreamReader streamReader = new StreamReader(filePathContractManagerXmlFile);
+            if (!(_contractManagerDataXmlSerializer.Deserialize(streamReader) is ContractManagerData contractManagerData))
+            {
+                streamReader.Close();
+                throw new NullReferenceException("contract manager data is null");
+            }
+            // Need to deep copy because the data loaded by the stream reader will be destroyed.
+            this.offeredContracts.Clear();
+            foreach (Contract.Contract contract in contractManagerData.offeredContracts)
+            {
+                Contract.Contract? clonedContract = contract.Clone(this.contractBlueprints);
+                if (clonedContract != null)
+                {
+                    this.offeredContracts.Add(clonedContract);
+                }
+            }
+            this.acceptedContracts.Clear();
+            foreach (Contract.Contract contract in contractManagerData.acceptedContracts)
+            {
+                Contract.Contract? clonedContract = contract.Clone(this.contractBlueprints);
+                if (clonedContract != null)
+                {
+                    this.acceptedContracts.Add(clonedContract);
+                }
+            }
+            this.finishedContracts.Clear();
+            foreach (Contract.Contract contract in contractManagerData.finishedContracts)
+            {
+                Contract.Contract? clonedContract = contract.Clone(this.contractBlueprints);
+                if (clonedContract != null)
+                {
+                    this.finishedContracts.Add(clonedContract);
+                }
+            }
+            this.maxNumberOfOfferedContracts = contractManagerData.maxNumberOfOfferedContracts;
+            this.maxNumberOfAcceptedContracts = contractManagerData.maxNumberOfAcceptedContracts;
+
+            streamReader.Close();
+        }
+
+        // Write data to save file
+        public void WriteTo(DirectoryInfo directory)
+        {
+            Console.WriteLine("[CM] ContractManager.WriteTo(directory)");
+            XmlHelper.SerializeWithoutNaN(_contractManagerDataXmlSerializer, this, Path.Combine(directory.FullName, "contractmanager.xml"));
+        }
+    }
+}

--- a/ContractManager/Patches/UncompressedSavePatch.cs
+++ b/ContractManager/Patches/UncompressedSavePatch.cs
@@ -1,0 +1,34 @@
+﻿using HarmonyLib;
+using KSA;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContractManager.Patches
+{
+    [HarmonyPatch]
+    internal static class UncompressedSavePatchLoad
+    {
+        private static Harmony? _harmony = new Harmony("ContractManager");
+
+        public static void Patch()
+        {
+            Console.WriteLine("[CM] Patching UncompressedSave...");
+            _harmony?.PatchAll(typeof(UncompressedSavePatchLoad).Assembly);
+        }
+
+        public static void Unload()
+        {
+            _harmony?.UnpatchAll(_harmony.Id);
+            _harmony = null;
+        }
+
+        [HarmonyPatch(typeof(KSA.UncompressedSave), nameof(KSA.UncompressedSave.Load))]
+        [HarmonyPostfix]
+        public static void LoadPostfix(ref KSA.UncompressedSave __instance)
+        {
+            Console.WriteLine($"[CM] UncompressedSavePatchLoad.LoadPostfix() loading data from '{__instance.Directory.FullName}'");
+            ContractManager.data.LoadFrom(__instance.Directory.FullName);
+        }
+    }
+}

--- a/ContractManager/Patches/UniverseDataPatch.cs
+++ b/ContractManager/Patches/UniverseDataPatch.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using KSA;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ContractManager.Patches
+{
+    [HarmonyPatch]
+    internal static class UniverseDataPatchWriteTo
+    {
+        // Patch a `Postfix` to write contract manager data after `KSA.UniverseData.WriteTo()` is called.
+        // Note, can't do prefix or postfix to `KSA.UncompressedSave.Write()` because save directory would be deleted, or `CacheStrings` is already called.
+        
+        private static Harmony? _harmony = new Harmony("ContractManager");
+
+        public static void Patch()
+        {
+            Console.WriteLine("[CM] Patching UniverseData...");
+            _harmony?.PatchAll(typeof(UniverseDataPatchWriteTo).Assembly);
+        }
+
+        public static void Unload()
+        {
+            _harmony?.UnpatchAll(_harmony.Id);
+            _harmony = null;
+        }
+
+        [HarmonyPatch(typeof(KSA.UniverseData), nameof(KSA.UniverseData.WriteTo), typeof(DirectoryInfo))]
+        [HarmonyPostfix]
+        public static void WriteToPostfix(DirectoryInfo directory)
+        {
+            Console.WriteLine($"[CM] UniverseDataPatchWriteTo.WriteToPostfix() writing data to '{directory.FullName}'");
+            ContractManager.data.WriteTo(directory);
+        }
+    }
+}


### PR DESCRIPTION
See #27 and #39
feat: Implemented `ContractManagerData` class
feat: Implemented saving and loading of that data as part of the Load/Save window in-game.
feat: Created Harmony patches to hook onto the load and save calls.
feat: Added clone functions to ensure the volatile loaded data is deep copied.
change: Made the data a static member of `ContractManager` and allow others to access it by `ContractManager.data`