### PR TITLE
Move `ActionType` and `TriggerType`outside the `Action` class definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
-- Add typing for the supported primitives for XML serialization. (#19)
+- Add typing for the supported primitives for XML serialization. (#66)
+
+### Changes
+
+- Moved `ActionType` outside the `Action` class definition. (#67)
+- Moved `TriggerType` outside the `Action` class definition. (#67)
 
 ## [0.1.0] - 2025-12-30
 

--- a/ContractManager/Contract/Contract.cs
+++ b/ContractManager/Contract/Contract.cs
@@ -186,7 +186,7 @@ namespace ContractManager.Contract
             {
                 this.status = ContractStatus.Failed;
                 this.finishedTimeS = playerTime;
-                ContractUtils.TriggerAction(this, ContractBlueprint.Action.TriggerType.OnContractFail);
+                ContractUtils.TriggerAction(this, ContractBlueprint.TriggerType.OnContractFail);
             }
         }
 
@@ -198,7 +198,7 @@ namespace ContractManager.Contract
             {
                 this.status = ContractStatus.Completed;
                 this.finishedTimeS = playerTime;
-                ContractUtils.TriggerAction(this, ContractBlueprint.Action.TriggerType.OnContractComplete);
+                ContractUtils.TriggerAction(this, ContractBlueprint.TriggerType.OnContractComplete);
             }
         }
     }

--- a/ContractManager/Contract/ContractUtils.cs
+++ b/ContractManager/Contract/ContractUtils.cs
@@ -113,7 +113,7 @@ namespace ContractManager.Contract
         }
 
         // Trigger action of the given type.
-        internal static void TriggerAction(Contract contract, ContractBlueprint.Action.TriggerType triggerType) {
+        internal static void TriggerAction(Contract contract, ContractBlueprint.TriggerType triggerType) {
             if (contract._contractBlueprint == null) {  return; }
             foreach (ContractBlueprint.Action action in contract._contractBlueprint.actions) {
                 if (action.trigger == triggerType) {

--- a/ContractManager/ContractBlueprint/Action.cs
+++ b/ContractManager/ContractBlueprint/Action.cs
@@ -5,22 +5,6 @@ namespace ContractManager.ContractBlueprint
 {
     public class Action
     {
-        public enum ActionType
-        {
-            [XmlEnum("showMessage")]
-            ShowMessage,
-            [XmlEnum("showBlockingPopup")]
-            ShowBlockingPopup,
-        }
-
-        public enum TriggerType
-        {
-            [XmlEnum("onContractComplete")]
-            OnContractComplete,
-            [XmlEnum("onContractFail")]
-            OnContractFail
-        }
-
         // The trigger of the action.
         [XmlElement("trigger")]
         public TriggerType trigger { get; set; }
@@ -71,5 +55,21 @@ namespace ContractManager.ContractBlueprint
                 }
             );
         }
+    }
+
+    public enum ActionType
+    {
+        [XmlEnum("showMessage")]
+        ShowMessage,
+        [XmlEnum("showBlockingPopup")]
+        ShowBlockingPopup,
+    }
+
+    public enum TriggerType
+    {
+        [XmlEnum("onContractComplete")]
+        OnContractComplete,
+        [XmlEnum("onContractFail")]
+        OnContractFail
     }
 }

--- a/ContractManager/ContractBlueprint/Generate.cs
+++ b/ContractManager/ContractBlueprint/Generate.cs
@@ -61,14 +61,14 @@ namespace ContractManager.ContractBlueprint
             
             contractToWrite.actions.Add(new Action
             {
-                trigger = Action.TriggerType.OnContractComplete,
-                type = Action.ActionType.ShowMessage,
+                trigger = TriggerType.OnContractComplete,
+                type = ActionType.ShowMessage,
                 showMessage = "Congratulations! You pounced the example contract."
             });
             contractToWrite.actions.Add(new Action
             {
-                trigger = Action.TriggerType.OnContractFail,
-                type = Action.ActionType.ShowMessage,
+                trigger = TriggerType.OnContractFail,
+                type = ActionType.ShowMessage,
                 showMessage = "Keep persevering; The road to success is pawed with failure."
             });
 
@@ -171,14 +171,14 @@ namespace ContractManager.ContractBlueprint
             
             contractToWrite.actions.Add(new Action
             {
-                trigger = Action.TriggerType.OnContractComplete,
-                type = Action.ActionType.ShowMessage,
+                trigger = TriggerType.OnContractComplete,
+                type = ActionType.ShowMessage,
                 showMessage = "Congratulations! You pounced the example contract."
             });
             contractToWrite.actions.Add(new Action
             {
-                trigger = Action.TriggerType.OnContractFail,
-                type = Action.ActionType.ShowMessage,
+                trigger = TriggerType.OnContractFail,
+                type = ActionType.ShowMessage,
                 showMessage = "Keep persevering; The road to success is pawed with failure."
             });
 


### PR DESCRIPTION
Move `ActionType` outside the `Action` class definition.
Move `TriggerType` outside the `Action` class definition.