### PR TITLE
Add expiration of an offered contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,19 @@
 - Add validation methods to contract blueprint and fields. (#68)
 - Add try-catch to catch XML serialization errors. (#68)
 - Add loading contract blueprints from other (mod) folders. (#69)
+- Add expiration of an offered contract. (#71)
+- Add 'expiration' as a field to contract blueprint, and show in contract details. (#71)
+- Add 'isRejectable' as a field to contract blueprint, and gray-out the reject button if the offered contract cannot be rejected. (#71)
+- Add gray-out the accept button if the offered contract cannot be accepted because of `maxNumberOfAcceptedContracts`. (#71)
 
-### Changes
+### Changed
 
 - Moved `ActionType` outside the `Action` class definition. (#67)
 - Moved `TriggerType` outside the `Action` class definition. (#67)
+
+### Fixed
+- Fix using `Universe.GetElapsedSimTime()` instead of `Program.GetPlayerTime()` to get the in-game time. (#71)
+- Fix use Colors constants for the acept and reject button. (#71)
 
 ## [0.1.0] - 2025-12-30
 

--- a/ContractManager/ContractBlueprint/ContractBlueprint.cs
+++ b/ContractManager/ContractBlueprint/ContractBlueprint.cs
@@ -27,6 +27,14 @@ namespace ContractManager.ContractBlueprint
         [XmlElement("description", DataType = "string")]
         public string description { get; set; } = string.Empty;
 
+        // When an offered contract will expired, in seconds
+        [XmlElement("expiration", DataType = "double")]
+        public double expiration { get; set; } = double.PositiveInfinity;  // Never expires
+
+        // Flag if an offered contract from this blueprint can be rejected.
+        [XmlElement("isRejectable", DataType = "boolean")]
+        public bool isRejectable { get; set; } = true;
+
         // List of prerequisites for the contract
         [XmlArray("prerequisites")]
         public List<Prerequisite> prerequisites { get; set; } = new List<Prerequisite>();

--- a/ContractManager/Utils.cs
+++ b/ContractManager/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using ContractManager.Contract;
+using KSA;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -27,6 +28,76 @@ namespace ContractManager
                 unit = "";
             }
             return String.Format(format, distance, unit);
+        }
+
+        public static string FormatSimTimeAsYearDayTime(KSA.SimTime simTime)
+        {
+            if (simTime.IsNaN())
+            {
+                return "NaN";
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendFormat("{0:0000} ", Math.Floor(simTime.Years));
+            stringBuilder.AppendFormat("{0:000} ", Math.Floor(simTime.Days) % TimeConstants.daysInMonth);
+
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Hours) % TimeConstants.hoursInDay);
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Minutes) % TimeConstants.minutesInHour);
+            stringBuilder.AppendFormat("{0:00}", Math.Floor(simTime.Seconds()) % TimeConstants.secondsInMinute);
+
+            return stringBuilder.ToString();
+        }
+
+        public static string FormatSimTimeAsDateTime(KSA.SimTime simTime)
+        {
+            if (simTime.IsNaN())
+            {
+                return "NaN";
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendFormat("{0:0000}-", Math.Floor(simTime.Years));
+            stringBuilder.AppendFormat("{0:00}-", Math.Floor(simTime.Months) % TimeConstants.monthsInYear);
+            stringBuilder.AppendFormat("{0:00} ", Math.Floor(simTime.Days) % TimeConstants.daysInMonth);
+
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Hours) % TimeConstants.hoursInDay);
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Minutes) % TimeConstants.minutesInHour);
+            stringBuilder.AppendFormat("{0:00}", Math.Floor(simTime.Seconds()) % TimeConstants.secondsInMinute);
+
+            return stringBuilder.ToString();
+        }
+
+        public static string FormatSimTimeAsRelative(KSA.SimTime simTime, bool showOnlyNonZero = false)
+        {
+            if (simTime.IsNaN())
+            {
+                return "NaN";
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (!showOnlyNonZero) {
+                stringBuilder.AppendFormat("{0:0000} ", Math.Floor(simTime.Years));
+                stringBuilder.AppendFormat("{0:000} ", Math.Floor(simTime.Days) % TimeConstants.daysInMonth);
+            }
+            else
+            {
+                if (simTime.Years >= 1)
+                {
+                    stringBuilder.AppendFormat("{0:0} ", Math.Floor(simTime.Years));
+                    stringBuilder.AppendFormat("{0:000} ", Math.Floor(simTime.Days));
+                }
+                else
+                if (simTime.Days >= 1)
+                {
+                    stringBuilder.AppendFormat("{0:0} ", Math.Floor(simTime.Days));
+                }
+            }
+
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Hours) % TimeConstants.hoursInDay);
+            stringBuilder.AppendFormat("{0:00}:", Math.Floor(simTime.Minutes) % TimeConstants.minutesInHour);
+            stringBuilder.AppendFormat("{0:00}", Math.Floor(simTime.Seconds()) % TimeConstants.secondsInMinute);
+
+            return stringBuilder.ToString();
         }
     }
     internal class Colors
@@ -102,4 +173,15 @@ namespace ContractManager
             return Colors.gray;
         }
     }
+
+    public class TimeConstants
+    {
+        public static double secondsInMinute = 60;
+        public static double minutesInHour = 60;
+        public static int hoursInDay = 24;
+        public static int daysInMonth = 30;
+        public static int monthsInYear = 12;
+        public static int daysInYear = 360;
+    }
+
 }

--- a/contracts/example_contract_001.xml
+++ b/contracts/example_contract_001.xml
@@ -8,6 +8,8 @@
 First, change the Periapsis to within 150 and 200 km altitude. 
 Next, change the Apoapsis to within 150 and 200 km altitude.
   </description>
+  <expiration>3600.0</expiration>
+  <expiration>3600.0</expiration>
   <prerequisites>
     <Prerequisite>
       <type>maxNumOfferedContracts</type>

--- a/contracts/example_contract_002.xml
+++ b/contracts/example_contract_002.xml
@@ -8,6 +8,7 @@
 First, change the Periapsis to within 150 and 200 km altitude. 
 Next, change the Apoapsis to within 150 and 200 km altitude.
 Then, change both Apoapsis and Periapsis to with 200 and 220km altitude.</description>
+  <isRejectable>false</isRejectable>
   <prerequisites>
     <Prerequisite>
       <type>maxNumOfferedContracts</type>


### PR DESCRIPTION
- Add expiration of an offered contract.
- Add 'expiration' as a field to contract blueprint, and show in contract details.
- Add 'isRejectable' as a field to contract blueprint, and gray-out the reject button if the offered contract cannot be rejected.
- Add gray-out the accept button if the offered contract cannot be accepted because of `maxNumberOfAcceptedContracts`.
- Fix using `Universe.GetElapsedSimTime()` instead of `Program.GetPlayerTime()` to get the in-game time.
- Fix use Colors constants for the acept and reject button.