### PR TITLE
Implement failing a contract by timeout, and auto-accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,25 @@
 
 ### Added
 
+GUI
+- Show expiration of an offered contract in contract details of *Contract Management Window*. (#71)
+- Gray-out the accept button if the offered contract cannot be accepted because of `maxNumberOfAcceptedContracts`. (#71)
+- Gray-out the reject button if the offered contract cannot be rejected because of `isRejectable`. (#71)
+- Show deadline of an accepted contract in contract details of *Contract Management Window*. (#72)
+- Show deadline of an accepted contract in *Active Contracts Window*. (#72)
+
+Core
 - Add typing for the supported primitives for XML serialization. (#66)
 - Add validation methods to contract blueprint and fields. (#68)
 - Add try-catch to catch XML serialization errors. (#68)
 - Add loading contract blueprints from other (mod) folders. (#69)
-- Add expiration of an offered contract. (#71)
-- Add 'expiration' as a field to contract blueprint, and show in contract details. (#71)
-- Add 'isRejectable' as a field to contract blueprint, and gray-out the reject button if the offered contract cannot be rejected. (#71)
-- Add gray-out the accept button if the offered contract cannot be accepted because of `maxNumberOfAcceptedContracts`. (#71)
+- Add 'expiration' as a field to contract blueprint. (#71)
+- Add expiring an offered contract. (#71)
+- Add 'isRejectable' as a field to contract blueprint. (#71)
+- Add 'deadline' as a field to contract blueprint. (#72)
+- Add failing of an accepted contract after the deadline passed. (#72)
+- Add 'isAutoAccepted' as field to contract blueprint. (#72)
+- Add when offering a contract to auto-accept when `isAutoAccepted` is true. (#72)
 
 ### Changed
 

--- a/ContractManager/Contract/Contract.cs
+++ b/ContractManager/Contract/Contract.cs
@@ -143,7 +143,16 @@ namespace ContractManager.Contract
             if (this.status != ContractStatus.Accepted) { return false; }
 
             ContractStatus previousStatus = this.status;
-            // TODO: Check if accepted contract expired -> Failed
+            // Check if accepted contract expired -> Failed
+            if (!Double.IsPositiveInfinity(this._contractBlueprint.deadline))
+            {
+                KSA.SimTime failOnSimTime = this.acceptedSimTime + this._contractBlueprint.deadline;
+                if (failOnSimTime < simTime)
+                {
+                    this.FailAcceptedContract(simTime);
+                    return true;
+                }
+            }
 
             // Update the tracked requirements, e.g. change the status
             ContractUtils.UpdateTrackedRequirements(this.trackedRequirements);

--- a/ContractManager/Contract/ContractUtils.cs
+++ b/ContractManager/Contract/ContractUtils.cs
@@ -90,8 +90,23 @@ namespace ContractManager.Contract
                 foundBlueprint = contractBlueprint.uid == blueprintUID;
                 if (foundBlueprint)
                 {
-                    // Found matching blueprint requirement.
+                    // Found matching contract blueprint.
                     return contractBlueprint;
+                }
+            }
+            return null;
+        }
+
+        internal static Contract? FindContractFromUID(List<Contract> contracts, string blueprintUID)
+        {
+            bool foundBlueprint = false;
+            foreach (Contract contract in contracts)
+            {
+                foundBlueprint = contract._contractBlueprint.uid == blueprintUID;
+                if (foundBlueprint)
+                {
+                    // Found matching contract.
+                    return contract;
                 }
             }
             return null;

--- a/ContractManager/ContractBlueprint/ContractBlueprint.cs
+++ b/ContractManager/ContractBlueprint/ContractBlueprint.cs
@@ -35,6 +35,14 @@ namespace ContractManager.ContractBlueprint
         [XmlElement("isRejectable", DataType = "boolean")]
         public bool isRejectable { get; set; } = true;
 
+        // When an accepted contract will fail, in seconds
+        [XmlElement("deadline", DataType = "double")]
+        public double deadline { get; set; } = double.PositiveInfinity;  // No deadline
+
+        // Flag if an offered contract is automatically accepted.
+        [XmlElement("isAutoAccepted", DataType = "boolean")]
+        public bool isAutoAccepted { get; set; } = false;
+
         // List of prerequisites for the contract
         [XmlArray("prerequisites")]
         public List<Prerequisite> prerequisites { get; set; } = new List<Prerequisite>();

--- a/ContractManager/GUI/ActiveContractsWindow.cs
+++ b/ContractManager/GUI/ActiveContractsWindow.cs
@@ -1,6 +1,7 @@
 ﻿using Brutal.ImGuiApi;
 using ContractManager.Contract;
 using ContractManager.ContractBlueprint;
+using KSA;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -62,6 +63,14 @@ namespace ContractManager.GUI
                     if (ImGui.SmallButton("Details"))
                     {
                         contractToShowDetails = contract;
+                    }
+
+                    if (!Double.IsPositiveInfinity(contract._contractBlueprint.deadline))
+                    {
+                        KSA.SimTime simTime = Universe.GetElapsedSimTime();
+                        KSA.SimTime deadlineOnSimTime = contract.acceptedSimTime + contract._contractBlueprint.deadline;
+                        KSA.SimTime deadlineInSimTime = deadlineOnSimTime - simTime;
+                        ImGui.Text(String.Format("Deadline in {0}", Utils.FormatSimTimeAsRelative(deadlineInSimTime, true)));
                     }
 
                     ImGui.Text(String.Format("Complete {0} requirement{1}", contract._contractBlueprint.completionCondition, contract._contractBlueprint.completionCondition == CompletionCondition.All ? "s" : ""));

--- a/ContractManager/GUI/ContractManagementWindow.cs
+++ b/ContractManager/GUI/ContractManagementWindow.cs
@@ -139,6 +139,10 @@ namespace ContractManager.GUI
                         {
                             ImGui.Text("Status: Completed.");
                         }
+                        if (this._contractToShowDetails.status == ContractStatus.Failed)
+                        {
+                            ImGui.Text("Status: Failed.");
+                        }
                         
                         if (this._contractToShowDetails._contractBlueprint.synopsis != string.Empty)
                         {
@@ -165,6 +169,28 @@ namespace ContractManager.GUI
                         else
                         {
                             ImGui.Text("Offered contract does not expire.");
+                        }
+
+                        if (!Double.IsPositiveInfinity(this._contractToShowDetails._contractBlueprint.deadline))
+                        {
+                            // Contract has a deadline
+                            if (this._contractToShowDetails.status == ContractStatus.Offered)
+                            {
+                                KSA.SimTime deadlineSimTime = new KSA.SimTime(this._contractToShowDetails._contractBlueprint.deadline);
+                                ImGui.Text(String.Format("Contract has a deadline of {0}", Utils.FormatSimTimeAsRelative(deadlineSimTime, true)));
+                            }
+                            else
+                            if (this._contractToShowDetails.status == ContractStatus.Accepted)
+                            {
+                                KSA.SimTime simTime = Universe.GetElapsedSimTime();
+                                KSA.SimTime deadlineOnSimTime = this._contractToShowDetails.acceptedSimTime + this._contractToShowDetails._contractBlueprint.deadline;
+                                KSA.SimTime deadlineInSimTime = deadlineOnSimTime - simTime;
+                                ImGui.Text(String.Format("Contract has a deadline on {0} in {1}", Utils.FormatSimTimeAsYearDayTime(deadlineOnSimTime), Utils.FormatSimTimeAsRelative(deadlineInSimTime, true)));
+                            }
+                        }
+                        else
+                        {
+                            ImGui.Text("Contract does not have a deadline.");
                         }
                         
                         ImGui.SeparatorText("Rewards");

--- a/contracts/example_contract_001.xml
+++ b/contracts/example_contract_001.xml
@@ -9,7 +9,8 @@ First, change the Periapsis to within 150 and 200 km altitude.
 Next, change the Apoapsis to within 150 and 200 km altitude.
   </description>
   <expiration>3600.0</expiration>
-  <expiration>3600.0</expiration>
+  <deadline>1800.0</deadline>
+  <isAutoAccepted>true</isAutoAccepted>
   <prerequisites>
     <Prerequisite>
       <type>maxNumOfferedContracts</type>

--- a/contracts/example_contract_002.xml
+++ b/contracts/example_contract_002.xml
@@ -9,6 +9,7 @@ First, change the Periapsis to within 150 and 200 km altitude.
 Next, change the Apoapsis to within 150 and 200 km altitude.
 Then, change both Apoapsis and Periapsis to with 200 and 220km altitude.</description>
   <isRejectable>false</isRejectable>
+  <deadline>3600.0</deadline>
   <prerequisites>
     <Prerequisite>
       <type>maxNumOfferedContracts</type>


### PR DESCRIPTION
- Add 'deadline' as a field to contract blueprint, and show in contract details and active contracts.
- Add failing a contract when the deadline passes.
- Add 'isAutoAccepted' as a field to contract blueprint, and auto-accept offered contracts.